### PR TITLE
Add notifications options for ItemAdded event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ plugin
 *.dll
 
 .mono
+.vs

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/TestNotifier.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/TestNotifier.cs
@@ -1,13 +1,14 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Jellyfin.Plugin.TelegramNotifier.Telegram.Configuration;
+namespace Jellyfin.Plugin.TelegramNotifier.Configuration;
 
 [Route("TelegramNotifierApi/TestNotifier")]
 [ApiController]
 public class TestNotifier : ControllerBase
 {
     private readonly Sender _sender;
+    private bool result;
 
     public TestNotifier(Sender sender)
     {
@@ -15,11 +16,11 @@ public class TestNotifier : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<string>> Get([FromQuery] string botToken, [FromQuery] string chatId)
+    public async Task<ActionResult<string>> Get([FromQuery] string botToken, [FromQuery] string chatId, [FromQuery] string? messageTest = null)
     {
-        string message = "[Jellyfin] Test message: \n 🎉 Your configuration is correct ! 🥳";
+        string message = string.IsNullOrEmpty(messageTest) ? "Test" : messageTest!;
 
-        bool result = await _sender.SendMessage("Test", message, botToken, chatId, false).ConfigureAwait(false);
+        result = await _sender.SendMessage("Test", message, botToken, chatId, false).ConfigureAwait(false);
 
         if (result)
         {

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/UserConfiguration.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/UserConfiguration.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TelegramNotifier.Configuration;
+﻿namespace Jellyfin.Plugin.TelegramNotifier.Configuration;
 
 public class UserConfiguration
 {
@@ -12,6 +12,8 @@ public class UserConfiguration
 
         ChatId = string.Empty;
 
+        MessageTest = string.Empty;
+
         EnableUser = false;
 
         SilentNotification = false;
@@ -19,9 +21,13 @@ public class UserConfiguration
         DoNotMentionOwnActivities = false;
 
         ItemAdded = false;
+
         ItemAddedMovie = false;
+
         ItemAddedSerie = false;
+
         ItemAddedSeason = false;
+
         ItemAddedEpisode = false;
 
         Generic = false;
@@ -67,6 +73,14 @@ public class UserConfiguration
         UserUpdated = false;
 
         UserDataSaved = false;
+
+        MessageItemAddedPrefix = string.Empty;
+
+        MessageItemAddedSuffix = string.Empty;
+
+        EnableItemAddedImage = false;
+
+        EnableItemAddedOverview = false;
     }
 
     public string? UserId { get; set; }
@@ -76,6 +90,8 @@ public class UserConfiguration
     public string? BotToken { get; set; }
 
     public string? ChatId { get; set; }
+
+    public string? MessageTest { get; set; }
 
     public bool? EnableUser { get; set; }
 
@@ -136,4 +152,12 @@ public class UserConfiguration
     public bool? UserUpdated { get; set; }
 
     public bool? UserDataSaved { get; set; }
+
+    public string? MessageItemAddedPrefix { get; set; }
+
+    public string? MessageItemAddedSuffix { get; set; }
+
+    public bool? EnableItemAddedImage { get; set; }
+
+    public bool? EnableItemAddedOverview { get; set; }
 }

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
@@ -1,5 +1,5 @@
 <div id="TelegramNotifierConfigPage" data-role="page" class="page type-interior pluginConfigurationPage"
-    data-require="emby-input,emby-button,emby-select,emby-checkbox" data-controller="__plugin/Telegram Notifier.js">
+     data-require="emby-input,emby-button,emby-select,emby-checkbox" data-controller="__plugin/Telegram Notifier.js">
     <div data-role="content">
         <div class="content-primary">
             <form id="TelegramNotifierConfigForm">
@@ -12,8 +12,8 @@
                 <div class="label">
                     You can find a guide in the "Use the plugin" section of the README.md file of the project.
                     <a is="emby-linkbutton" rel="noopener noreferrer"
-                        class="raised button-alt headerHelpButton emby-button" target="_blank"
-                        href="https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier"> README </a>
+                       class="raised button-alt headerHelpButton emby-button" target="_blank"
+                       href="https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier"> README </a>
                 </div>
                 <div class="sectionTitleContainer flex align-items-center">
                     <h2>Configuration</h2>
@@ -21,8 +21,10 @@
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="ServerUrl">Server URL</label>
                     <input id="ServerUrl" name="ServerUrl" type="text" is="emby-input" />
-                    <div class="fieldDescription">Insert the url of the jellyfin server (ex: localhost:8096,
-                        192.168.1.2:8096, jellyfin.myDomain.com, ...) </div>
+                    <div class="fieldDescription">
+                        Insert the url of the jellyfin server (ex: localhost:8096,
+                        192.168.1.2:8096, jellyfin.myDomain.com, ...)
+                    </div>
                 </div>
                 <div class="inputContainer">
                     <div class="selectContainer">
@@ -33,7 +35,7 @@
                     </div>
                 </div>
                 <div class="sectionTitleContainer flex align-items-center">
-                    <h3>---------- Telegram Bot Configuration ----------</h3>
+                    <h2>Telegram credentials</h2>
                 </div>
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="BotToken">Bot token</label>
@@ -45,13 +47,20 @@
                     <input id="ChatId" name="ChatId" type="text" is="emby-input" />
                     <div class="fieldDescription"> Insert the telegram chat id here. </div>
                 </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="MessageTest">Telegram message test</label>
+                    <input type="text" id="MessageTest" name="MessageTest" is="emby-input" />
+                    <div class="fieldDescription">
+                        Test message
+                    </div>
+                </div>
                 <div>
                     <button id="testButton" is="emby-button" class="raised button block emby-button">
                         <span>Test bot configuration</span>
                     </button>
                 </div>
                 <div class="sectionTitleContainer flex align-items-center">
-                    <h3>---------- Notification Configuration ---------- |Save at the end ↓|</h3>
+                    <h2>Notification Configuration</h2>
                 </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
@@ -62,14 +71,14 @@
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
                         <input id="SilentNotification" name="SilentNotificationCheckBox" type="checkbox"
-                            is="emby-checkbox" />
+                               is="emby-checkbox" />
                         <span>Silent notifications for this user</span>
                     </label>
                 </div>
                 <div class="checkboxContainer checkboxContainer-withDescription">
                     <label class="emby-checkbox-label">
                         <input id="DoNotMentionOwnActivities" name="DoNotMentionOwnActivitiesCheckBox" type="checkbox"
-                            is="emby-checkbox" />
+                               is="emby-checkbox" />
                         <span>Do not notify user's own activities</span>
                     </label>
                 </div>
@@ -92,14 +101,42 @@
                     <div data-name="notificationTypeContainer">
                     </div>
                 </div>
+                <div class="sectionTitleContainer flex align-items-center">
+                    <h2>Notification Options</h2>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="MessageItemAddedPrefix">Telegram message prefix</label>
+                    <input type="text" id="MessageItemAddedPrefix" name="MessageItemAddedPrefix" is="emby-input" />
+                    <div class="fieldDescription">
+                        Message prefix text
+                    </div>
+                </div>
+                <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="MessageItemAddedSuffix">Telegram message suffix</label>
+                    <input type="text" id="MessageItemAddedSuffix" name="MessageItemAddedSuffix" is="emby-input" />
+                    <div class="fieldDescription">
+                        Message suffix text
+                    </div>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label" for="EnableItemAddedImage">
+                        <input id="EnableItemAddedImage" name="EnableItemAddedImage" type="checkbox" is="emby-checkbox" />
+                        <span>Enable image of the item in notification</span>
+                    </label>
+                </div>
+                <div class="checkboxContainer checkboxContainer-withDescription">
+                    <label class="emby-checkbox-label" for="EnableItemAddedOverview">
+                        <input id="EnableItemAddedOverview" name="EnableItemAddedOverview" type="checkbox" is="emby-checkbox" />
+                        <span>Enable overview text of the item in notification</span>
+                    </label>
+                </div>
                 <div>
                     <button id="saveButton" is="emby-button" type="submit"
-                        class="raised button-submit block emby-button">
+                            class="raised button-submit block emby-button">
                         <span>Save</span>
                     </button>
                 </div>
+            </form>
         </div>
-        </form>
     </div>
-</div>
 </div>

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.js
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.js
@@ -1,4 +1,4 @@
-export default function (view) {
+﻿export default function (view) {
 
     const TelegramNotifierConfig = {
         pluginUniqueId: 'fd76211d-17e0-4a72-a23f-c6eeb1e48b3a',
@@ -127,17 +127,27 @@ export default function (view) {
                     document.querySelector('#ServerUrl').value = config.ServerUrl;
                     document.querySelector('#BotToken').value = userConfig.BotToken;
                     document.querySelector('#ChatId').value = userConfig.ChatId;
+                    document.querySelector('#MessageTest').value = userConfig.MessageTest;
                     document.querySelector('#EnableUser').checked = userConfig.EnableUser;
                     document.querySelector('#SilentNotification').checked = userConfig.SilentNotification;
                     document.querySelector('#DoNotMentionOwnActivities').checked = userConfig.DoNotMentionOwnActivities;
+                    document.querySelector('#MessageItemAddedPrefix').value = userConfig.MessageItemAddedPrefix;
+                    document.querySelector('#MessageItemAddedSuffix').value = userConfig.MessageItemAddedSuffix;
+                    document.querySelector('#EnableItemAddedImage').checked = userConfig.EnableItemAddedImage;
+                    document.querySelector('#EnableItemAddedOverview').checked = userConfig.EnableItemAddedOverview;
                     TelegramNotifierConfig.notificationType.loadNotificationTypes(userConfig);
                 } else {
                     document.querySelector('#ServerUrl').value = config.ServerUrl;
                     document.querySelector('#BotToken').value = '';
                     document.querySelector('#ChatId').value = '';
+                    document.querySelector('#MessageTest').value = "[Jellyfin] Test message: \n 🎉 Your configuration is correct ! 🥳";
                     document.querySelector('#EnableUser').checked = false;
                     document.querySelector('#SilentNotification').checked = false;
                     document.querySelector('#DoNotMentionOwnActivities').checked = false;
+                    document.querySelector('#MessageItemAddedPrefix').value = "🎬";
+                    document.querySelector('#MessageItemAddedSuffix').value = "added to library";
+                    document.querySelector('#EnableItemAddedImage').checked = false;
+                    document.querySelector('#EnableItemAddedOverview').checked = false;
                     TelegramNotifierConfig.notificationType.loadNotificationTypes(null);
                 }
                 Dashboard.hideLoadingMsg();
@@ -157,9 +167,14 @@ export default function (view) {
                         config.ServerUrl = document.querySelector('#ServerUrl').value;
                         userConfig.BotToken = document.querySelector('#BotToken').value;
                         userConfig.ChatId = document.querySelector('#ChatId').value;
+                        userConfig.MessageTest = document.querySelector('#MessageTest').value;
                         userConfig.EnableUser = document.querySelector('#EnableUser').checked;
                         userConfig.SilentNotification = document.querySelector('#SilentNotification').checked;
                         userConfig.DoNotMentionOwnActivities = document.querySelector('#DoNotMentionOwnActivities').checked;
+                        userConfig.MessageItemAddedPrefix = document.querySelector('#MessageItemAddedPrefix').value;
+                        userConfig.MessageItemAddedSuffix = document.querySelector('#MessageItemAddedSuffix').value;
+                        userConfig.EnableItemAddedImage = document.querySelector('#EnableItemAddedImage').checked;
+                        userConfig.EnableItemAddedOverview = document.querySelector('#EnableItemAddedOverview').checked;
                         TelegramNotifierConfig.notificationType.saveNotificationTypes(userConfig);
                     } else {
                         config.ServerUrl = document.querySelector('#ServerUrl').value;
@@ -168,9 +183,14 @@ export default function (view) {
                             UserName: document.querySelector('#userToConfigure').selectedOptions[0].text,
                             BotToken: document.querySelector('#BotToken').value,
                             ChatId: document.querySelector('#ChatId').value,
+                            MessageTest: document.querySelector('#MessageTest').value,
                             EnableUser: document.querySelector('#EnableUser').checked,
                             SilentNotification: document.querySelector('#SilentNotification').checked,
-                            DoNotMentionOwnActivities: document.querySelector('#DoNotMentionOwnActivities').checked
+                            DoNotMentionOwnActivities: document.querySelector('#DoNotMentionOwnActivities').checked,
+                            MessageItemAddedPrefix: document.querySelector('#MessageItemAddedPrefix').value,
+                            MessageItemAddedSuffix: document.querySelector('#MessageItemAddedSuffix').value,
+                            EnableItemAddedImage: document.querySelector('#EnableItemAddedImage').checked,
+                            EnableItemAddedOverview: document.querySelector('#EnableItemAddedOverview').checked
                         });
                         TelegramNotifierConfig.notificationType.saveNotificationTypes(config.UserConfigurations.find(x => x.UserId === TelegramNotifierConfig.user.getSelectedUserId()));
                     }
@@ -193,7 +213,8 @@ export default function (view) {
                     const userConfig = config.UserConfigurations.find(x => x.UserId === TelegramNotifierConfig.user.getSelectedUserId());
                     const params = {
                         botToken: userConfig.BotToken,
-                        chatId: userConfig.ChatId
+                        chatId: userConfig.ChatId,
+                        messageTest: userConfig.MessageTest
                     };
                     const url = new URL('/TelegramNotifierApi/TestNotifier', window.location.origin);
                     Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));

--- a/Jellyfin.Plugin.TelegramNotifier/Jellyfin.Plugin.TelegramNotifier.csproj
+++ b/Jellyfin.Plugin.TelegramNotifier/Jellyfin.Plugin.TelegramNotifier.csproj
@@ -12,7 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.9.7" />
+    <PackageReference Include="Jellyfin.Model" Version="10.9.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.TelegramNotifier/NotificationFormatter.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/NotificationFormatter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.TelegramNotifier.Configuration;
+
+namespace Jellyfin.Plugin.TelegramNotifier
+{
+    public class NotificationFormatter
+    {
+        private readonly Dictionary<NotificationFilter.NotificationType, Func<UserConfiguration, string, string>> _prefixFormatters;
+        private readonly Dictionary<NotificationFilter.NotificationType, Func<UserConfiguration, string>> _suffixFormatters;
+
+        public NotificationFormatter()
+        {
+            _prefixFormatters = new Dictionary<NotificationFilter.NotificationType, Func<UserConfiguration, string, string>>
+            {
+                [NotificationFilter.NotificationType.ItemAdded] = (user, subtype) => subtype switch
+                {
+                    "ItemAddedMovie" => user.MessageItemAddedPrefix ?? $"🎬",
+                    "ItemAddedSerie" => user.MessageItemAddedPrefix ?? $"📺 [Serie]",
+                    "ItemAddedSeason" => user.MessageItemAddedPrefix ?? $"📺",
+                    "ItemAddedEpisode" => user.MessageItemAddedPrefix ?? $"📺",
+                    _ => user.MessageItemAddedPrefix ?? string.Empty
+                },
+                // Add more types and their prefixes as needed
+            };
+
+            _suffixFormatters = new Dictionary<NotificationFilter.NotificationType, Func<UserConfiguration, string>>
+            {
+                [NotificationFilter.NotificationType.ItemAdded] = user => user.MessageItemAddedSuffix ?? string.Empty,
+                // Add more types and their suffixes as needed
+            };
+        }
+
+        public string GetPrefix(NotificationFilter.NotificationType type, UserConfiguration user, string subtype)
+        {
+            if (_prefixFormatters.TryGetValue(type, out var formatter))
+            {
+                return formatter(user, subtype);
+            }
+
+            return user.MessageItemAddedPrefix ?? string.Empty;
+        }
+
+        public string GetSuffix(NotificationFilter.NotificationType type, UserConfiguration user)
+        {
+            if (_suffixFormatters.TryGetValue(type, out var formatter))
+            {
+                return formatter(user);
+            }
+
+            return user.MessageItemAddedSuffix ?? string.Empty;
+        }
+
+        public string FormatMessage(NotificationFilter.NotificationType type, string message, UserConfiguration user, string subtype, string overview)
+        {
+            string prefix = GetPrefix(type, user, subtype);
+            string suffix = GetSuffix(type, user);
+            string overviewText = user.EnableItemAddedOverview == true && !string.IsNullOrEmpty(overview) ? $"\n\n{overview}" : string.Empty;
+            return $"{prefix} {message} {suffix} {overviewText}".Trim();
+        }
+    }
+}

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
@@ -64,37 +64,39 @@ public class ItemAddedManager : IItemAddedManager
 
                     _logger.LogDebug("Notifying for {ItemName}", item.Name);
 
-                    // Send notification.
-                    string message = $"🎬 {item.Name} ({item.ProductionYear})\n" +
-                                     $"      added to library";
-
-                    string subtype = "ItemAddedMovie";
+                    string? message, subtype, overview;
                     bool addImage = true;
 
                     switch (item)
                     {
                         case Series serie:
-                            message = $"📺 [Serie] {serie.Name} ({item.ProductionYear}) added to library";
+                            message = $"{serie.Name} ({item.ProductionYear})";
                             subtype = "ItemAddedSerie";
+                            overview = $"{serie.Overview}";
                             break;
 
                         case Season season:
-                            string seasonNumber = season.IndexNumber.HasValue ? season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture) : "00";
-
-                            message = $"📺 {season.Series.Name} ({item.ProductionYear})\n" +
-                                      $"      Season {seasonNumber} added to library";
+                            string seasonNumber = season.IndexNumber?.ToString("00", CultureInfo.InvariantCulture) ?? "00";
+                            message = $"{season.Series.Name} ({item.ProductionYear})\n" +
+                                      $"      Season {seasonNumber}";
                             subtype = "ItemAddedSeason";
+                            overview = string.Empty;
                             break;
 
                         case Episode episode:
                             addImage = false;
-                            string eSeasonNumber = episode.Season.IndexNumber.HasValue ? episode.Season.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture) : "00";
-                            string episodeNumber = episode.IndexNumber.HasValue ? episode.IndexNumber.Value.ToString("00", CultureInfo.InvariantCulture) : "00";
-
-                            message = $"📺 {episode.Series.Name} ({item.ProductionYear})\n" +
+                            string eSeasonNumber = episode.Season.IndexNumber?.ToString("00", CultureInfo.InvariantCulture) ?? "00";
+                            string episodeNumber = episode.IndexNumber?.ToString("00", CultureInfo.InvariantCulture) ?? "00";
+                            message = $"{episode.Series.Name} ({item.ProductionYear})\n" +
                                       $"      S{eSeasonNumber} - E{episodeNumber}\n" +
-                                      $"      '{item.Name}' added to library";
+                                      $"      '{item.Name}'";
                             subtype = "ItemAddedEpisode";
+                            overview = $"{episode.Overview}";
+                            break;
+                        default:
+                            message = $"{item.Name} ({item.ProductionYear})";
+                            subtype = "ItemAddedMovie";
+                            overview = $"{item.Overview}";
                             break;
                     }
 
@@ -103,11 +105,11 @@ public class ItemAddedManager : IItemAddedManager
                         string serverUrl = Plugin.Instance?.Configuration.ServerUrl ?? "localhost:8096";
                         string path = "http://" + serverUrl + "/Items/" + item.Id + "/Images/Primary";
 
-                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, message, imagePath: path, subtype: subtype).ConfigureAwait(false);
+                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, message, imagePath: path, subtype: subtype, overview: overview).ConfigureAwait(false);
                     }
                     else
                     {
-                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, message, subtype: subtype).ConfigureAwait(false);
+                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, message, subtype: subtype, overview: overview).ConfigureAwait(false);
                     }
 
                     // Remove item from queue.

--- a/Jellyfin.Plugin.TelegramNotifier/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/PluginServiceRegistrator.cs
@@ -28,6 +28,9 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         // Register notification filter.
         serviceCollection.AddScoped<NotificationFilter>();
 
+        // Register notification formatter
+        serviceCollection.AddSingleton<NotificationFormatter>();
+
         // Library consumers.
         serviceCollection.AddScoped<IEventConsumer<SubtitleDownloadFailureEventArgs>, SubtitleDownloadFailureNotifier>();
         serviceCollection.AddHostedService<ItemAddedNotifierEntryPoint>();


### PR DESCRIPTION
### Description:
I recently discovered your project and was initially using a custom fork of an older [plugin](https://github.com/MindFlavor/Jellyfin.Plugins.Telegram) to meet my needs. I have now adapted those needs to your plugin.

### Changes:
- Add ability to customize test message string

<img src="https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier/assets/2978767/a27e21b0-2189-46bd-afb0-cdf004257cd5" alt="Capture2" style="width:600px;" width="600">

- Enhanced ItemAdded event to support customizable message formatting with prefix and sufix.
- Added options to include or exclude image in notifications.
- Added options to include item overview in notifications.
- Improved and standardized some code and HTML text in the plugin settings page for better consolidation.

<img src="https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier/assets/2978767/a71534d4-72b7-456f-b39f-58b3aea2448f" alt="Capture2" style="width:600px;" width="600">

<img src="https://github.com/RomainPierre7/jellyfin-plugin-TelegramNotifier/assets/2978767/d0823add-8095-4527-8d3c-0bebb56d2181" alt="Capture2" style="width:300px;" width="300">

Best regards,
