### PR TITLE
feat: add ServerDisplayUrl configuration option and update related logic

### DIFF
--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/PluginConfiguration.cs
@@ -15,6 +15,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string ServerUrl { get; set; }
 
+    public string ServerDisplayUrl { get; set; }
+
     public bool EnablePlugin { get; set; }
 
     /// <summary>

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
@@ -39,6 +39,14 @@
                         logs to see if the image URL is correct.</div>
                 </div>
                 <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="ServerDisplayUrl">Server Display URL (Optional)</label>
+                    <input id="ServerDisplayUrl" name="ServerDisplayUrl" type="text" is="emby-input" />
+                    <div class="fieldDescription">Insert an alternative server URL to display in notifications (ex: jellyfin.myDomain.com,
+                        my-jellyfin.local:8096, ...). If set, this will be used in {server.Url} placeholders instead of the Server URL above.
+                        The url must include the http/https protocol. This is useful if your server is behind a reverse proxy.
+                    </div>
+                </div>
+                <div class="inputContainer">
                     <div class="selectContainer">
                         <label class="selectLabel" for="userToConfigure">User to configure</label>
                         <select id="userToConfigure" name="userToConfigure" class="emby-select-withcolor emby-select">

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.html
@@ -41,9 +41,9 @@
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="ServerDisplayUrl">Server Display URL (Optional)</label>
                     <input id="ServerDisplayUrl" name="ServerDisplayUrl" type="text" is="emby-input" />
-                    <div class="fieldDescription">Insert an alternative server URL to display in notifications (ex: jellyfin.myDomain.com,
-                        my-jellyfin.local:8096, ...). If set, this will be used in {server.Url} placeholders instead of the Server URL above.
-                        The url must include the http/https protocol. This is useful if your server is behind a reverse proxy.
+                    <div class="fieldDescription">Insert an alternative server URL to display in notifications (ex: https://jellyfin.myDomain.com,
+                        https://my-jellyfin.local:8096, ...). If set, this will be used in {server.Url} placeholders instead of the Server URL above.
+                        You may include the http/https protocol; if omitted, http:// will be automatically added. This is useful if your server is behind a reverse proxy.
                     </div>
                 </div>
                 <div class="inputContainer">

--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.js
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/Web/configPage.js
@@ -214,6 +214,7 @@ export default function (view) {
                 const userConfig = config.UserConfigurations.find(x => x.UserId === TelegramNotifierConfig.user.getSelectedUserId());
                 if (userConfig) {
                     document.querySelector('#ServerUrl').value = config.ServerUrl;
+                    document.querySelector('#ServerDisplayUrl').value = config.ServerDisplayUrl || '';
                     document.querySelector('#BotToken').value = userConfig.BotToken;
                     document.querySelector('#ChatId').value = userConfig.ChatId;
                     document.querySelector('#ThreadId').value = userConfig.ThreadId;
@@ -224,6 +225,7 @@ export default function (view) {
                     TelegramNotifierConfig.notificationType.loadNotificationTypes(userConfig);
                 } else {
                     document.querySelector('#ServerUrl').value = config.ServerUrl;
+                    document.querySelector('#ServerDisplayUrl').value = config.ServerDisplayUrl || '';
                     document.querySelector('#BotToken').value = '';
                     document.querySelector('#ChatId').value = '';
                     document.querySelector('#ThreadId').value = '';
@@ -245,9 +247,10 @@ export default function (view) {
                 Dashboard.showLoadingMsg();
                 ApiClient.getPluginConfiguration(TelegramNotifierConfig.pluginUniqueId).then(function (config) {
                     config.EnablePlugin = document.querySelector('#EnablePlugin').checked;
+                    config.ServerUrl = document.querySelector('#ServerUrl').value;
+                    config.ServerDisplayUrl = document.querySelector('#ServerDisplayUrl').value;
                     const userConfig = config.UserConfigurations.find(x => x.UserId === TelegramNotifierConfig.user.getSelectedUserId());
                     if (userConfig) {
-                        config.ServerUrl = document.querySelector('#ServerUrl').value;
                         userConfig.BotToken = document.querySelector('#BotToken').value;
                         userConfig.ChatId = document.querySelector('#ChatId').value;
                         userConfig.ThreadId = document.querySelector('#ThreadId').value;
@@ -257,7 +260,6 @@ export default function (view) {
                         userConfig.KeepSerieImage = document.querySelector('#KeepSerieImage').checked;
                         TelegramNotifierConfig.notificationType.saveNotificationTypes(userConfig);
                     } else {
-                        config.ServerUrl = document.querySelector('#ServerUrl').value;
                         config.UserConfigurations.push({
                             UserId: TelegramNotifierConfig.user.getSelectedUserId(),
                             UserName: document.querySelector('#userToConfigure').selectedOptions[0].text,

--- a/Jellyfin.Plugin.TelegramNotifier/MessageParser.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/MessageParser.cs
@@ -70,10 +70,18 @@ namespace Jellyfin.Plugin.TelegramNotifier
                 object effectiveItem = GetEffectiveItem(objEventArgs);
 
                 string serverUrl = "http://localhost:8096";
-                if (Plugin.Instance?.Configuration != null && !string.IsNullOrEmpty(Plugin.Instance.Configuration.ServerUrl))
+                if (Plugin.Instance?.Configuration != null)
                 {
-                    var url = Plugin.Instance.Configuration.ServerUrl.Trim();
-                    serverUrl = url.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? url : "http://" + url;
+                    // Use ServerDisplayUrl if set, otherwise fall back to ServerUrl
+                    string urlToUse = !string.IsNullOrEmpty(Plugin.Instance.Configuration.ServerDisplayUrl)
+                        ? Plugin.Instance.Configuration.ServerDisplayUrl
+                        : Plugin.Instance.Configuration.ServerUrl;
+
+                    if (!string.IsNullOrEmpty(urlToUse))
+                    {
+                        var url = urlToUse.Trim();
+                        serverUrl = url.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? url : "http://" + url;
+                    }
                 }
 
                 var replacements = new Dictionary<string, string?>


### PR DESCRIPTION
Server url uses forced http, added an extra config option to let the user configure the display url for the telegram messages.

Additionally, it's now possible to do something like:

```
<b>New Episode Added</b>
📺 {episode.Series.Name} - S{eSeasonNumber} - E{episodeNumber} - '{item.Name}'

📽 <a href="{server.Url}/web/index.html#/details?id={item.Id}">Watch</a>
```

Without having the server url pointing to localhost
