### PR TITLE
Fix item notifications after late metadata refresh

### DIFF
--- a/Jellyfin.Plugin.TelegramNotifier/Configuration/TestNotifier.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Configuration/TestNotifier.cs
@@ -19,9 +19,9 @@ public class TestNotifier : ControllerBase
     {
         string message = "[Jellyfin] Test message: \n 🎉 Your configuration is correct ! 🥳";
 
-        bool result = await _sender.SendMessage("Test", message, botToken, chatId, false, threadId).ConfigureAwait(false);
+        TelegramMessageResult? result = await _sender.SendMessage("Test", message, botToken, chatId, false, threadId).ConfigureAwait(false);
 
-        if (result)
+        if (result is not null)
         {
             return Ok("Message sent successfully");
         }

--- a/Jellyfin.Plugin.TelegramNotifier/NotificationFilter.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/NotificationFilter.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.TelegramNotifier.Configuration;
+using Jellyfin.Plugin.TelegramNotifier.Notifiers.ItemAddedNotifier;
+using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
@@ -14,15 +17,18 @@ namespace Jellyfin.Plugin.TelegramNotifier
         private readonly ILogger<Plugin> _logger;
         private readonly ILibraryManager _libraryManager;
         private readonly IMediaSourceManager _mediaSourceManager;
+        private readonly ItemNotificationStore _itemNotificationStore;
 
         public NotificationFilter(
             Sender sender,
             ILibraryManager libraryManager,
-            IMediaSourceManager mediaSourceManager)
+            IMediaSourceManager mediaSourceManager,
+            ItemNotificationStore itemNotificationStore)
         {
             _sender = sender;
             _libraryManager = libraryManager;
             _mediaSourceManager = mediaSourceManager;
+            _itemNotificationStore = itemNotificationStore;
             _logger = Plugin.Logger;
         }
 
@@ -95,15 +101,15 @@ namespace Jellyfin.Plugin.TelegramNotifier
             }
         }
 
-        public async Task Filter(NotificationType type, dynamic eventArgs, string userId = "", string imagePath = "", string subtype = "")
+        public async Task<IReadOnlyList<ItemNotificationRecord>> Filter(NotificationType type, dynamic eventArgs, string userId = "", string imagePath = "", string subtype = "", Guid? trackedItemId = null)
         {
             if (!Plugin.Config.EnablePlugin)
             {
-                return;
+                return Array.Empty<ItemNotificationRecord>();
             }
 
             UserConfiguration[] users = Plugin.Config.UserConfigurations;
-            var tasks = new List<Task>();
+            var tasks = new List<Task<ItemNotificationRecord?>>();
 
             foreach (UserConfiguration user in users)
             {
@@ -166,11 +172,21 @@ namespace Jellyfin.Plugin.TelegramNotifier
                 {
                     if (string.IsNullOrEmpty(imagePath))
                     {
-                        Task task = _sender.SendMessage(type.ToString(), message, botToken, chatId, isSilentNotification, threadId);
+                        Task<ItemNotificationRecord?> task = SendAndTrackAsync(
+                            type.ToString(),
+                            message,
+                            botToken,
+                            chatId,
+                            threadId,
+                            user.UserId ?? string.Empty,
+                            isSilentNotification,
+                            string.Empty,
+                            trackedItemId);
                         tasks.Add(task);
                     }
                     else
                     {
+                        string notificationImagePath = imagePath;
                         Episode episode = null;
 
                         // Case 1 : eventArgs is an Episode
@@ -196,12 +212,20 @@ namespace Jellyfin.Plugin.TelegramNotifier
 
                         if (user.KeepSerieImage && episode != null)
                         {
-
                             string serverUrl = Plugin.Instance?.Configuration.ServerUrl ?? "localhost:8096";
-                            imagePath = "http://" + serverUrl + "/Items/" + episode.Series.Id + "/Images/Primary";
+                            notificationImagePath = "http://" + serverUrl + "/Items/" + episode.Series.Id + "/Images/Primary";
                         }
 
-                        Task task = _sender.SendMessageWithPhoto(type.ToString(), message, imagePath, botToken, chatId, isSilentNotification, threadId);
+                        Task<ItemNotificationRecord?> task = SendAndTrackAsync(
+                            type.ToString(),
+                            message,
+                            botToken,
+                            chatId,
+                            threadId,
+                            user.UserId ?? string.Empty,
+                            isSilentNotification,
+                            notificationImagePath,
+                            trackedItemId);
                         tasks.Add(task);
                     }
                 }
@@ -211,7 +235,76 @@ namespace Jellyfin.Plugin.TelegramNotifier
                 }
             }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+            ItemNotificationRecord?[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            return results.Where(result => result is not null).Cast<ItemNotificationRecord>().ToArray();
+        }
+
+        public async Task UpdateItemAddedNotifications(BaseItem item, string subtype, IReadOnlyList<ItemNotificationRecord> records)
+        {
+            foreach (ItemNotificationRecord record in records)
+            {
+                UserConfiguration? user = Plugin.Config.UserConfigurations.FirstOrDefault(candidate =>
+                    candidate.EnableUser &&
+                    candidate.ItemAdded &&
+                    candidate.ChatId == record.ChatId &&
+                    candidate.ThreadId == record.ThreadId &&
+                    (string.IsNullOrEmpty(record.UserId) || candidate.UserId == record.UserId));
+
+                if (user is null || !GetPropertyValue(user, subtype))
+                {
+                    continue;
+                }
+
+                string template = GetPropertyMessage(user, subtype);
+                string message = MessageParser.ParseMessage(template, item, _libraryManager, _mediaSourceManager);
+                if (message == record.RenderedMessage)
+                {
+                    continue;
+                }
+
+                bool updated = record.HasPhoto
+                    ? await _sender.EditMessageCaption(NotificationType.ItemAdded.ToString(), message, user.BotToken, record.ChatId, record.MessageId).ConfigureAwait(false)
+                    : await _sender.EditMessageText(NotificationType.ItemAdded.ToString(), message, user.BotToken, record.ChatId, record.MessageId).ConfigureAwait(false);
+
+                if (updated)
+                {
+                    record.RenderedMessage = message;
+                    await _itemNotificationStore.UpdateAsync(record).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task<ItemNotificationRecord?> SendAndTrackAsync(
+            string notificationType,
+            string message,
+            string botToken,
+            string chatId,
+            string threadId,
+            string userId,
+            bool isSilentNotification,
+            string imagePath,
+            Guid? trackedItemId)
+        {
+            TelegramMessageResult? result = string.IsNullOrEmpty(imagePath)
+                ? await _sender.SendMessage(notificationType, message, botToken, chatId, isSilentNotification, threadId).ConfigureAwait(false)
+                : await _sender.SendMessageWithPhoto(notificationType, message, imagePath, botToken, chatId, isSilentNotification, threadId).ConfigureAwait(false);
+
+            if (result is null || trackedItemId is null)
+            {
+                return null;
+            }
+
+            return new ItemNotificationRecord
+            {
+                ItemId = trackedItemId.Value,
+                UserId = userId,
+                ChatId = chatId,
+                ThreadId = threadId,
+                MessageId = result.MessageId,
+                HasPhoto = !string.IsNullOrEmpty(imagePath),
+                RenderedMessage = message,
+                SentAtUtc = DateTime.UtcNow
+            };
         }
     }
 }

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/IItemAddedManager.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/IItemAddedManager.cs
@@ -8,4 +8,6 @@ public interface IItemAddedManager
     public Task ProcessItemsAsync();
 
     public void AddItem(BaseItem item);
+
+    public void UpdateItem(BaseItem item);
 }

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedManager.cs
@@ -18,17 +18,22 @@ public class ItemAddedManager : IItemAddedManager
     private readonly ILogger<ItemAddedManager> _logger;
     private readonly ILibraryManager _libraryManager;
     private readonly IServerApplicationHost _applicationHost;
+    private readonly ItemNotificationStore _itemNotificationStore;
     private readonly ConcurrentDictionary<Guid, QueuedItemContainer> _itemProcessQueue;
+    private readonly ConcurrentDictionary<Guid, byte> _itemUpdateQueue;
 
     public ItemAddedManager(
         ILogger<ItemAddedManager> logger,
         ILibraryManager libraryManager,
-        IServerApplicationHost applicationHost)
+        IServerApplicationHost applicationHost,
+        ItemNotificationStore itemNotificationStore)
     {
         _logger = logger;
         _libraryManager = libraryManager;
         _applicationHost = applicationHost;
+        _itemNotificationStore = itemNotificationStore;
         _itemProcessQueue = new ConcurrentDictionary<Guid, QueuedItemContainer>();
+        _itemUpdateQueue = new ConcurrentDictionary<Guid, byte>();
     }
 
     public async Task ProcessItemsAsync()
@@ -36,7 +41,8 @@ public class ItemAddedManager : IItemAddedManager
         _logger.LogDebug("ProcessItemsAsync");
         // Attempt to process all items in queue.
         var currentItems = _itemProcessQueue.ToArray();
-        if (currentItems.Length != 0)
+        var updatedItems = _itemUpdateQueue.ToArray();
+        if (currentItems.Length != 0 || updatedItems.Length != 0)
         {
             var scope = _applicationHost.ServiceProvider!.CreateAsyncScope();
             var notificationFilter = scope.ServiceProvider.GetRequiredService<NotificationFilter>();
@@ -50,7 +56,7 @@ public class ItemAddedManager : IItemAddedManager
                     {
                         // Remove item from queue.
                         _itemProcessQueue.TryRemove(key, out _);
-                        return;
+                        continue;
                     }
 
                     _logger.LogDebug("Item {ItemName}", item.Name);
@@ -66,59 +72,47 @@ public class ItemAddedManager : IItemAddedManager
 
                     _logger.LogDebug("Notifying for {ItemName}", item.Name);
 
-                    string subtype = "ItemAddedMovies";
-                    bool addImage = true;
+                    string subtype = GetSubtype(item);
+                    string serverUrl = Plugin.Instance?.Configuration.ServerUrl ?? "localhost:8096";
+                    string path = "http://" + serverUrl + "/Items/" + item.Id + "/Images/Primary";
 
-                    dynamic eventArgs = item;
-
-                    switch (item)
-                    {
-                        case Series serie:
-                            subtype = "ItemAddedSeries";
-                            eventArgs = serie;
-                            break;
-
-                        case Season season:
-                            subtype = "ItemAddedSeasons";
-                            eventArgs = season;
-                            break;
-
-                        case Episode episode:
-                            subtype = "ItemAddedEpisodes";
-                            eventArgs = episode;
-                            break;
-
-                        case MusicAlbum album:
-                            subtype = "ItemAddedAlbums";
-                            eventArgs = album;
-                            break;
-
-                        case Audio audio:
-                            subtype = "ItemAddedSongs";
-                            eventArgs = audio;
-                            break;
-
-                        case Book book:
-                            subtype = "ItemAddedBooks";
-                            eventArgs = book;
-                            break;
-                    }
-
-                    if (addImage)
-                    {
-                        string serverUrl = Plugin.Instance?.Configuration.ServerUrl ?? "localhost:8096";
-                        string path = "http://" + serverUrl + "/Items/" + item.Id + "/Images/Primary";
-
-                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, eventArgs, imagePath: path, subtype: subtype).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await notificationFilter.Filter(NotificationFilter.NotificationType.ItemAdded, eventArgs, subtype: subtype).ConfigureAwait(false);
-                    }
+                    var records = await notificationFilter.Filter(
+                        NotificationFilter.NotificationType.ItemAdded,
+                        item,
+                        imagePath: path,
+                        subtype: subtype,
+                        trackedItemId: item.Id).ConfigureAwait(false);
+                    await _itemNotificationStore.AddAsync(records).ConfigureAwait(false);
 
                     // Remove item from queue.
                     _itemProcessQueue.TryRemove(key, out _);
                 }
+
+                foreach (var updatedItem in updatedItems)
+                {
+                    Guid key = updatedItem.Key;
+                    _itemUpdateQueue.TryRemove(key, out _);
+                    try
+                    {
+                        var records = await _itemNotificationStore.GetAsync(key).ConfigureAwait(false);
+                        if (records.Count == 0)
+                        {
+                            continue;
+                        }
+
+                        BaseItem? item = _libraryManager.GetItemById(key);
+                        if (item is not null)
+                        {
+                            await notificationFilter.UpdateItemAddedNotifications(item, GetSubtype(item), records).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Could not update Telegram notifications for item {ItemId}", key);
+                    }
+                }
+
+                await _itemNotificationStore.PurgeExpiredAsync().ConfigureAwait(false);
             }
         }
         else
@@ -140,5 +134,24 @@ public class ItemAddedManager : IItemAddedManager
             _logger.LogDebug("Not queueing {ItemName} for notification because the it is a disabled library", item.Name);
         }
 
+    }
+
+    public void UpdateItem(BaseItem item)
+    {
+        _itemUpdateQueue.TryAdd(item.Id, 0);
+    }
+
+    private static string GetSubtype(BaseItem item)
+    {
+        return item switch
+        {
+            Series => "ItemAddedSeries",
+            Season => "ItemAddedSeasons",
+            Episode => "ItemAddedEpisodes",
+            MusicAlbum => "ItemAddedAlbums",
+            Audio => "ItemAddedSongs",
+            Book => "ItemAddedBooks",
+            _ => "ItemAddedMovies"
+        };
     }
 }

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedNotifierEntryPoint.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemAddedNotifierEntryPoint.cs
@@ -27,28 +27,47 @@ public class ItemAddedNotifierEntryPoint : IHostedService
         }
 
         // Only notify on books, movies, series, seasons, episodes, albums and audio.
-        if (itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Movies.Movie) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Series) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Season) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Episode) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Audio.MusicAlbum) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Audio.Audio) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Book) ||
-        itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.AudioBook))
+        if (IsSupportedItem(itemChangeEventArgs))
         {
             _itemAddedManager.AddItem(itemChangeEventArgs.Item);
         }
     }
 
+    private void ItemUpdatedHandler(object? sender, ItemChangeEventArgs itemChangeEventArgs)
+    {
+        const ItemUpdateType MetadataUpdates = ItemUpdateType.MetadataImport |
+            ItemUpdateType.MetadataDownload |
+            ItemUpdateType.MetadataEdit;
+
+        if ((itemChangeEventArgs.UpdateReason & MetadataUpdates) != 0 && IsSupportedItem(itemChangeEventArgs))
+        {
+            _itemAddedManager.UpdateItem(itemChangeEventArgs.Item);
+        }
+    }
+
+    private static bool IsSupportedItem(ItemChangeEventArgs itemChangeEventArgs)
+    {
+        return itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Movies.Movie) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Series) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Season) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.TV.Episode) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Audio.MusicAlbum) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Audio.Audio) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.Book) ||
+            itemChangeEventArgs.Item.GetType() == typeof(MediaBrowser.Controller.Entities.AudioBook);
+    }
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _libraryManager.ItemAdded += ItemAddedHandler;
+        _libraryManager.ItemUpdated += ItemUpdatedHandler;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
         _libraryManager.ItemAdded -= ItemAddedHandler;
+        _libraryManager.ItemUpdated -= ItemUpdatedHandler;
         return Task.CompletedTask;
     }
 }

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemNotificationRecord.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemNotificationRecord.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Jellyfin.Plugin.TelegramNotifier.Notifiers.ItemAddedNotifier;
+
+public sealed class ItemNotificationRecord
+{
+    public Guid ItemId { get; set; }
+
+    public string UserId { get; set; } = string.Empty;
+
+    public string ChatId { get; set; } = string.Empty;
+
+    public string ThreadId { get; set; } = string.Empty;
+
+    public long MessageId { get; set; }
+
+    public bool HasPhoto { get; set; }
+
+    public string RenderedMessage { get; set; } = string.Empty;
+
+    public DateTime SentAtUtc { get; set; }
+}

--- a/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemNotificationStore.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Notifiers/ItemAddedNotifier/ItemNotificationStore.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TelegramNotifier.Notifiers.ItemAddedNotifier;
+
+public sealed class ItemNotificationStore : IDisposable
+{
+    private static readonly TimeSpan RecordLifetime = TimeSpan.FromDays(7);
+    private readonly ILogger<ItemNotificationStore> _logger;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private readonly string _storePath;
+    private List<ItemNotificationRecord> _records;
+
+    public ItemNotificationStore(ILogger<ItemNotificationStore> logger)
+    {
+        _logger = logger;
+        _storePath = Path.Combine(Plugin.Instance!.DataFolderPath, "item-notifications.json");
+        _records = Load();
+    }
+
+    public async Task<IReadOnlyList<ItemNotificationRecord>> GetAsync(Guid itemId)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return _records.Where(record => record.ItemId == itemId).ToArray();
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task AddAsync(IEnumerable<ItemNotificationRecord> records)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            foreach (ItemNotificationRecord record in records)
+            {
+                _records.RemoveAll(existing =>
+                    existing.ItemId == record.ItemId &&
+                    existing.ChatId == record.ChatId &&
+                    existing.ThreadId == record.ThreadId &&
+                    existing.MessageId == record.MessageId);
+                _records.Add(record);
+            }
+
+            RemoveExpiredRecords();
+            await SaveAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task UpdateAsync(ItemNotificationRecord record)
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            ItemNotificationRecord? existing = _records.FirstOrDefault(candidate =>
+                candidate.ItemId == record.ItemId &&
+                candidate.ChatId == record.ChatId &&
+                candidate.ThreadId == record.ThreadId &&
+                candidate.MessageId == record.MessageId);
+
+            if (existing is not null)
+            {
+                existing.RenderedMessage = record.RenderedMessage;
+                await SaveAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public async Task PurgeExpiredAsync()
+    {
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (RemoveExpiredRecords())
+            {
+                await SaveAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
+
+    private List<ItemNotificationRecord> Load()
+    {
+        try
+        {
+            if (!File.Exists(_storePath))
+            {
+                return new List<ItemNotificationRecord>();
+            }
+
+            string json = File.ReadAllText(_storePath);
+            return JsonSerializer.Deserialize<List<ItemNotificationRecord>>(json) ?? new List<ItemNotificationRecord>();
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "Could not load tracked Telegram item notifications");
+            return new List<ItemNotificationRecord>();
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Could not parse tracked Telegram item notifications");
+            return new List<ItemNotificationRecord>();
+        }
+    }
+
+    private bool RemoveExpiredRecords()
+    {
+        DateTime cutoff = DateTime.UtcNow.Subtract(RecordLifetime);
+        return _records.RemoveAll(record => record.SentAtUtc < cutoff) > 0;
+    }
+
+    private async Task SaveAsync()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_storePath)!);
+        string json = JsonSerializer.Serialize(_records);
+        await File.WriteAllTextAsync(_storePath, json).ConfigureAwait(false);
+    }
+}

--- a/Jellyfin.Plugin.TelegramNotifier/PluginServiceRegistrator.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/PluginServiceRegistrator.cs
@@ -32,6 +32,7 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         // Library consumers.
         serviceCollection.AddScoped<IEventConsumer<SubtitleDownloadFailureEventArgs>, SubtitleDownloadFailureNotifier>();
         serviceCollection.AddHostedService<ItemAddedNotifierEntryPoint>();
+        serviceCollection.AddSingleton<ItemNotificationStore>();
         serviceCollection.AddSingleton<IItemAddedManager, ItemAddedManager>();
         serviceCollection.AddHostedService<ItemDeletedNotifierEntryPoint>();
         serviceCollection.AddSingleton<IItemDeletedManager, ItemDeletedManager>();

--- a/Jellyfin.Plugin.TelegramNotifier/Sender.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/Sender.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -63,7 +65,7 @@ namespace Jellyfin.Plugin.TelegramNotifier
             }
         }
 
-        public async Task<bool> SendMessage(string notificationType, string message, string botToken, string chatId, bool isSilentNotification, string threadId)
+        public async Task<TelegramMessageResult?> SendMessage(string notificationType, string message, string botToken, string chatId, bool isSilentNotification, string threadId)
         {
             try
             {
@@ -89,19 +91,24 @@ namespace Jellyfin.Plugin.TelegramNotifier
                 var content = new FormUrlEncodedContent(parameters);
 
                 HttpResponseMessage response = await _httpClient.PostAsync(url, content).ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
+                TelegramMessageResult? result = await ReadMessageResultAsync(response).ConfigureAwait(false);
 
                 _logger.LogInformation("({NotificationType}): Message sent successfully.", notificationType);
-                return true;
+                return result;
             }
             catch (HttpRequestException)
             {
                 _logger.LogError("({NotificationType}): Message could not be sent, please check your configuration (botToken: {BotToken}, chatId: {ChatId}, threadId: {ThreadId}), your template, your internet connection or the Telegram API.", notificationType, botToken, chatId, threadId);
-                return false;
+                return null;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "({NotificationType}): Telegram returned an invalid response.", notificationType);
+                return null;
             }
         }
 
-        public async Task<bool> SendMessageWithPhoto(string notificationType, string message, string imageUrl, string botToken, string chatId, bool isSilentNotification, string threadId)
+        public async Task<TelegramMessageResult?> SendMessageWithPhoto(string notificationType, string message, string imageUrl, string botToken, string chatId, bool isSilentNotification, string threadId)
         {
             try
             {
@@ -128,16 +135,82 @@ namespace Jellyfin.Plugin.TelegramNotifier
                 formData.Add(imageContent, "photo", "image.png");
 
                 HttpResponseMessage response = await _httpClient.PostAsync(url, formData).ConfigureAwait(false);
-                response.EnsureSuccessStatusCode();
+                TelegramMessageResult? result = await ReadMessageResultAsync(response).ConfigureAwait(false);
 
                 _logger.LogInformation("({NotificationType}): Message sent successfully.", notificationType);
-                return true;
+                return result;
             }
             catch (HttpRequestException)
             {
                 _logger.LogError("({NotificationType}): Message could not be sent, please check your configuration.", notificationType);
+                return null;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "({NotificationType}): Telegram returned an invalid response.", notificationType);
+                return null;
+            }
+        }
+
+        public Task<bool> EditMessageText(string notificationType, string message, string botToken, string chatId, long messageId)
+        {
+            return EditMessage(notificationType, "editMessageText", "text", message, botToken, chatId, messageId);
+        }
+
+        public Task<bool> EditMessageCaption(string notificationType, string message, string botToken, string chatId, long messageId)
+        {
+            return EditMessage(notificationType, "editMessageCaption", "caption", message, botToken, chatId, messageId);
+        }
+
+        private async Task<bool> EditMessage(string notificationType, string method, string messageParameter, string message, string botToken, string chatId, long messageId)
+        {
+            try
+            {
+                string url = $"https://api.telegram.org/bot{botToken}/{method}";
+                var parameters = new Dictionary<string, string>
+                {
+                    { "chat_id", chatId },
+                    { "message_id", messageId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+                    { messageParameter, message },
+                    { "parse_mode", "HTML" }
+                };
+
+                using var content = new FormUrlEncodedContent(parameters);
+                HttpResponseMessage response = await _httpClient.PostAsync(url, content).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
+                _logger.LogInformation("({NotificationType}): Message updated successfully.", notificationType);
+                return true;
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "({NotificationType}): Message {MessageId} could not be updated.", notificationType, messageId);
                 return false;
             }
+        }
+
+        private static async Task<TelegramMessageResult?> ReadMessageResultAsync(HttpResponseMessage response)
+        {
+            response.EnsureSuccessStatusCode();
+            using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            TelegramApiResponse? apiResponse = await JsonSerializer.DeserializeAsync<TelegramApiResponse>(stream).ConfigureAwait(false);
+            return apiResponse?.Ok == true && apiResponse.Result is not null
+                ? new TelegramMessageResult(apiResponse.Result.MessageId)
+                : null;
+        }
+
+        private sealed class TelegramApiResponse
+        {
+            [JsonPropertyName("ok")]
+            public bool Ok { get; set; }
+
+            [JsonPropertyName("result")]
+            public TelegramMessage? Result { get; set; }
+        }
+
+        private sealed class TelegramMessage
+        {
+            [JsonPropertyName("message_id")]
+            public long MessageId { get; set; }
         }
     }
 }

--- a/Jellyfin.Plugin.TelegramNotifier/TelegramMessageResult.cs
+++ b/Jellyfin.Plugin.TelegramNotifier/TelegramMessageResult.cs
@@ -1,0 +1,11 @@
+namespace Jellyfin.Plugin.TelegramNotifier;
+
+public sealed class TelegramMessageResult
+{
+    public TelegramMessageResult(long messageId)
+    {
+        MessageId = messageId;
+    }
+
+    public long MessageId { get; }
+}


### PR DESCRIPTION
Fixes #73.

## What changed

- parse and retain the Telegram `message_id` returned by `sendMessage` and `sendPhoto`
- persist item-to-message mappings for seven days so metadata updates still work after a Jellyfin restart
- subscribe to metadata-related `ItemUpdated` events and queue notification refreshes
- re-render the configured item-added template and call `editMessageCaption` for photo notifications or `editMessageText` for text notifications
- skip the Telegram edit when the rendered message has not changed
- support multiple configured recipients without storing bot tokens in the tracking file

This keeps the existing retry behavior. If the retry window expires and a notification is sent with filename-derived metadata, a later successful identification updates the existing Telegram message instead of sending a duplicate.

## Validation

- `dotnet build Jellyfin.Plugin.TelegramNotifier.sln --configuration Release`
- 0 errors
- no new analyzer warnings compared with `main`
